### PR TITLE
Ensure riemann connection is closed at the end of metrics lifecycle

### DIFF
--- a/src/onyx/metrics/riemann.clj
+++ b/src/onyx/metrics/riemann.clj
@@ -3,8 +3,7 @@
             [riemann.client :as r]
             [taoensso.timbre :refer [info warn fatal]]
             [clojure.set :refer [rename-keys]]
-            [interval-metrics.core :as im]
-            [clojure.tools.logging :as log]))
+            [interval-metrics.core :as im]))
 
 (defn metric->riemann-event [metric]
   (-> metric 
@@ -66,5 +65,5 @@
                     (swap! timeout-count inc)
                     (recur (next-sleep-time sleep))))))))
         (finally
-          (log/info "Closing riemann connection.")
+          (info "Closing riemann connection.")
           (r/close! client))))))

--- a/src/onyx/metrics/riemann.clj
+++ b/src/onyx/metrics/riemann.clj
@@ -3,7 +3,8 @@
             [riemann.client :as r]
             [taoensso.timbre :refer [info warn fatal]]
             [clojure.set :refer [rename-keys]]
-            [interval-metrics.core :as im]))
+            [interval-metrics.core :as im]
+            [clojure.tools.logging :as log]))
 
 (defn metric->riemann-event [metric]
   (-> metric 
@@ -41,25 +42,29 @@
           client (r/tcp-client {:host address :port defaulted-port})
           timeout-count (atom 0)]
         
-      (while (not (Thread/interrupted)) 
-        (let [events (map metric->riemann-event (read-batch ch batch-size batch-timeout))]
-          (when-not (empty? events) 
-            (loop [sleep 0]
-              ;; Exponential backoff to rate limit errors
-              (when-not (zero? sleep) 
-                (info (format "Message send timeout count %s. Backing off %s." @timeout-count sleep))
-                (Thread/sleep sleep))
+      (try
+        (while (not (Thread/interrupted))
+          (let [events (map metric->riemann-event (read-batch ch batch-size batch-timeout))]
+            (when-not (empty? events) 
+              (loop [sleep 0]
+                ;; Exponential backoff to rate limit errors
+                (when-not (zero? sleep) 
+                  (info (format "Message send timeout count %s. Backing off %s." @timeout-count sleep))
+                  (Thread/sleep sleep))
 
-              (let [result (try
-                             (-> client 
-                                 (r/send-events events)
-                                 (deref defaulted-timeout ::timeout))
-                             (catch InterruptedException e
-                               ;; Intentionally pass.
-                               )
-                             (catch Throwable e
-                               (warn e "Lost riemann connection" address port)
-                               ::exception))]
-                (when (#{::exception ::timeout} result)
-                  (swap! timeout-count inc)
-                  (recur (next-sleep-time sleep)))))))))))
+                (let [result (try
+                               (-> client 
+                                   (r/send-events events)
+                                   (deref defaulted-timeout ::timeout))
+                               (catch InterruptedException e
+                                 ;; Intentionally pass.
+                                 )
+                               (catch Throwable e
+                                 (warn e "Lost riemann connection" address port)
+                                 ::exception))]
+                  (when (#{::exception ::timeout} result)
+                    (swap! timeout-count inc)
+                    (recur (next-sleep-time sleep))))))))
+        (finally
+          (log/info "Closing riemann connection.")
+          (r/close! client))))))


### PR DESCRIPTION
Fixes the riemann metrics lifecycle from leaking unnecessary open riemann connections after a job shuts down.
